### PR TITLE
Refactor/cad provider supply

### DIFF
--- a/src/containers/Dash/index.js
+++ b/src/containers/Dash/index.js
@@ -4,7 +4,7 @@ import styles from './style.module.css'
 const Dash = () => {
   return (
     <div className={styles.bgWrapperDash}>
-      <img src="../../bgDash1.png" className={styles.imageDash} alt="dash banner" />
+      <img src="../../bgDash1.png" className={styles.imageDash} alt='bg-dash' />
     </div>
   );
 };

--- a/src/containers/Supply/Register/Provider/index.js
+++ b/src/containers/Supply/Register/Provider/index.js
@@ -8,7 +8,7 @@ import {
   validateCNPJ,
   validateEmail,
 } from '../../../../utils/validators'
-import masks from '../../../../utils/masks'
+import masks, { applyMask } from '../../../../utils/masks'
 
 const { Title } = Typography
 
@@ -171,6 +171,20 @@ const AddProviderSup = ({ form, handleSubmit }) => {
                           message: 'Telefone do contato é obrigatório',
                         },
                       ]}
+                      onChange={({ target: { value }}) => {
+                        const contacts = form.getFieldValue('contacts')
+
+                        contacts.splice(
+                          field.name,
+                          1,
+                          {
+                            ...contacts[field.name],
+                            telphone: applyMask('telphone', value)
+                          }
+                        )
+
+                        form.setFieldsValue({contacts})
+                      }}
                       label="Telefone"
                     >
                       <Input />

--- a/src/containers/Supply/Register/Provider/index.js
+++ b/src/containers/Supply/Register/Provider/index.js
@@ -126,15 +126,15 @@ const AddProviderSup = ({ form, handleSubmit }) => {
                   <Col span={8}>
                     <Form.Item
                       {...field}
-                      name={[field.name, 'name']}
                       fieldKey={[field.fieldKey, 'name']}
+                      label="Nome"
+                      name={[field.name, 'name']}
                       rules={[
                         {
-                          required: true,
                           message: 'Nome do contato é obrigatório',
+                          required: true,
                         },
                       ]}
-                      label="Nome"
                     >
                       <Input />
                     </Form.Item>
@@ -142,20 +142,20 @@ const AddProviderSup = ({ form, handleSubmit }) => {
                   <Col span={8}>
                     <Form.Item
                       {...field}
-                      name={[field.name, 'email']}
                       fieldKey={[field.fieldKey, 'email']}
+                      label="Email"
+                      name={[field.name, 'email']}
                       rules={[
                         {
-                          required: true,
                           message: 'Email do contato é obrigatório',
+                          required: true,
                         },
                         {
+                          message: 'Formato de email incorreto',
                           validator: async (_, value) =>
                             await validateEmail(value),
-                          message: 'Formato de email incorreto',
                         },
                       ]}
-                      label="Email"
                     >
                       <Input />
                     </Form.Item>
@@ -163,14 +163,9 @@ const AddProviderSup = ({ form, handleSubmit }) => {
                   <Col span={7}>
                     <Form.Item
                       {...field}
-                      name={[field.name, 'telphone']}
                       fieldKey={[field.fieldKey, 'telphone']}
-                      rules={[
-                        {
-                          required: true,
-                          message: 'Telefone do contato é obrigatório',
-                        },
-                      ]}
+                      label="Telefone"
+                      name={[field.name, 'telphone']}
                       onChange={({ target: { value }}) => {
                         const contacts = form.getFieldValue('contacts')
 
@@ -182,10 +177,14 @@ const AddProviderSup = ({ form, handleSubmit }) => {
                             telphone: applyMask('telphone', value)
                           }
                         )
-
                         form.setFieldsValue({contacts})
                       }}
-                      label="Telefone"
+                      rules={[
+                        {
+                          message: 'Telefone do contato é obrigatório',
+                          required: true,
+                        },
+                      ]}
                     >
                       <Input />
                     </Form.Item>

--- a/src/containers/Supply/Register/Provider/index.js
+++ b/src/containers/Supply/Register/Provider/index.js
@@ -1,0 +1,208 @@
+import React from 'react'
+import { Button, Col, Form, Input, Row, Typography } from 'antd'
+import { map } from 'ramda'
+import { PlusOutlined, MinusCircleOutlined } from '@ant-design/icons'
+
+import {
+  validateCEP,
+  validateCNPJ,
+  validateEmail,
+} from '../../../../utils/validators'
+import masks from '../../../../utils/masks'
+
+const { Title } = Typography
+
+const renderFormItem = (form) => ({ key, label, name, rules, span }) => (
+  <Col key={key} span={span}>
+    <Form.Item label={label} name={name} rules={rules}>
+      <Input onChange={({ target: { value } }) => masks(form, name, value)} />
+    </Form.Item>
+  </Col>
+)
+
+const fieldsForm = (form) => [
+  {
+    key: 'cnpj',
+    label: 'CNPJ',
+    name: 'cnpj',
+    rules: [
+      { required: true },
+      { validator: (_, value) => validateCNPJ(form, value) },
+    ],
+    span: 8,
+  },
+  {
+    key: 'razaoSocial',
+    label: 'Razão social',
+    name: 'razaoSocial',
+    rules: [{ required: true }],
+    span: 16,
+  },
+  {
+    key: 'zipCode',
+    label: 'CEP',
+    name: 'zipCode',
+    rules: [
+      { required: true },
+      { validator: async (_, value) => await validateCEP(form, value) },
+    ],
+    span: 5,
+  },
+  {
+    key: 'state',
+    label: 'UF',
+    name: 'state',
+    rules: [{ required: true }, { len: 2 }],
+    span: 3,
+  },
+  {
+    key: 'city',
+    label: 'Cidade',
+    name: 'city',
+    rules: [{ required: true }],
+    span: 16,
+  },
+  {
+    key: 'neighborhood',
+    label: 'Bairro',
+    name: 'neighborhood',
+    rules: [{ required: true }],
+    span: 8,
+  },
+  {
+    key: 'street',
+    label: 'Logradouro',
+    name: 'street',
+    rules: [{ required: true }],
+    span: 12,
+  },
+  {
+    key: 'number',
+    label: 'Número',
+    name: 'number',
+    rules: [{ required: true }],
+    span: 4,
+  },
+  {
+    key: 'complement',
+    label: 'Complemento',
+    name: 'complement',
+    rules: [],
+    span: 12,
+  },
+  {
+    key: 'referencePoint',
+    label: 'Ponto de referência',
+    name: 'referencePoint',
+    rules: [],
+    span: 12,
+  },
+]
+
+const AddProviderSup = ({ form, handleSubmit }) => {
+  return (
+    <>
+      <Row justify="center">
+        <Col>
+          <Title level={3}>Fornecedor Sup</Title>
+        </Col>
+      </Row>
+
+      <Form
+        form={form}
+        layout="vertical"
+        onFinish={handleSubmit}
+        validateTrigger="onBlur"
+      >
+        <Row gutter={[20, 8]}>{map(renderFormItem(form), fieldsForm(form))}</Row>
+        <Form.List
+          initialValue={[{ name: '', email: '', telphone: '' }]}
+          name="contacts"
+        >
+          {(fields, { add, remove }) => (
+            <>
+              {fields.map((field) => (
+                <Row gutter={[20, 8]}>
+                  <Col span={8}>
+                    <Form.Item
+                      {...field}
+                      name={[field.name, 'name']}
+                      fieldKey={[field.fieldKey, 'name']}
+                      rules={[
+                        {
+                          required: true,
+                          message: 'Nome do contato é obrigatório',
+                        },
+                      ]}
+                      label="Nome"
+                    >
+                      <Input />
+                    </Form.Item>
+                  </Col>
+                  <Col span={8}>
+                    <Form.Item
+                      {...field}
+                      name={[field.name, 'email']}
+                      fieldKey={[field.fieldKey, 'email']}
+                      rules={[
+                        {
+                          required: true,
+                          message: 'Email do contato é obrigatório',
+                        },
+                        {
+                          validator: async (_, value) =>
+                            await validateEmail(value),
+                          message: 'Formato de email incorreto',
+                        },
+                      ]}
+                      label="Email"
+                    >
+                      <Input />
+                    </Form.Item>
+                  </Col>
+                  <Col span={7}>
+                    <Form.Item
+                      {...field}
+                      name={[field.name, 'telphone']}
+                      fieldKey={[field.fieldKey, 'telphone']}
+                      rules={[
+                        {
+                          required: true,
+                          message: 'Telefone do contato é obrigatório',
+                        },
+                      ]}
+                      label="Telefone"
+                    >
+                      <Input />
+                    </Form.Item>
+                  </Col>
+                  {fields.length > 1 && (
+                    <Form.Item label={' '}>
+                      <MinusCircleOutlined onClick={() => remove(field.name)} />
+                    </Form.Item>
+                  )}
+                </Row>
+              ))}
+              <Form.Item>
+                <Button onClick={() => add()} block icon={<PlusOutlined />}>
+                  Adicionar
+                </Button>
+              </Form.Item>
+            </>
+          )}
+        </Form.List>
+        <Row justify="end">
+          <Col>
+            <Form.Item>
+              <Button htmlType="submit" type="primary">
+                Salvar
+              </Button>
+            </Form.Item>
+          </Col>
+        </Row>
+      </Form>
+    </>
+  )
+}
+
+export default AddProviderSup

--- a/src/pages/Supply/Register/Provider/index.js
+++ b/src/pages/Supply/Register/Provider/index.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { Form, message } from 'antd'
+
+import AddProviderSupContainer from '../../../../containers/Supply/Register/Provider'
+import buildProvider from '../../../../utils/providerSpec'
+import { NovoFornecedor } from '../../../../services/Suprimentos/fornecedor'
+
+const messageErrorText = 'Erro ao cadastrar fornecedor'
+const messageSuccessText = 'Fornecedor cadastrado com sucesso'
+
+const AddProviderSup = () => {
+  const [form] = Form.useForm()
+
+  const handleSubmit = async (providerFormData) => {
+    try {
+      const { status } = await NovoFornecedor(buildProvider(providerFormData))
+
+      if (status === 404 || status === 422 || status === 500) {
+        throw new Error('422 Unprocessable Entity!')
+      }
+
+      form.resetFields()
+      message.success(messageSuccessText)
+    } catch (err) {
+      console.log(err)
+      message.error(messageErrorText)
+    }
+  }
+
+  return <AddProviderSupContainer form={form} handleSubmit={handleSubmit} />
+}
+
+export default AddProviderSup

--- a/src/pages/Supply/Register/Provider/index.js
+++ b/src/pages/Supply/Register/Provider/index.js
@@ -22,7 +22,6 @@ const AddProviderSup = () => {
       form.resetFields()
       message.success(messageSuccessText)
     } catch (err) {
-      console.log(err)
       message.error(messageErrorText)
     }
   }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import { Redirect, Route, Switch } from 'react-router-dom'
 
 import AddKitRoute from './Gerenciar/Kit'
-import CadastroFornecedorSupRoute from './Suprimentos/Cad.Fornecedor'
+import CadastroFornecedorSupRoute from './Supply/Register/Provider'
 import CadastroProdutosSupRoute from './Suprimentos/Cad.Produtos'
 import Dash from './Dash'
 import EditarFornecedorSupRoute from './Suprimentos/Edit.Fornecedor'

--- a/src/stories/containers/Supply/Register/Provider/index.js
+++ b/src/stories/containers/Supply/Register/Provider/index.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Form } from 'antd'
+import { action } from '@storybook/addon-actions'
+
+import AddProviderSupContainer from '../../../../../containers/Supply/Register/Provider'
+import buildProvider from '../../../../../utils/providerSpec'
+
+export default {
+  title: 'Containers/Supply/Register/Provider',
+  component: AddProviderSupContainer,
+}
+
+const handleSubmitAction = action('Register new provider')
+
+const Template = () => {
+  const [form] = Form.useForm()
+
+  const handleSubmit = (providerFormData) => {
+    form.resetFields()
+    handleSubmitAction(buildProvider(providerFormData))
+  }
+
+  return (
+    <AddProviderSupContainer form={form} handleSubmit={handleSubmit} />
+  )
+}
+
+export const AddProvider = Template.bind({})

--- a/src/utils/masks.js
+++ b/src/utils/masks.js
@@ -1,6 +1,6 @@
 import { length } from 'ramda'
 
-export default (form, name, value) => {
+export const applyMask = (name, value) => {
   let valueMasked = value
 
   switch (name) {
@@ -67,5 +67,10 @@ export default (form, name, value) => {
     default:
   }
 
-  return form.setFieldsValue({ [name]: valueMasked })
+  return valueMasked
+}
+
+export default (form, name, value) => {
+  
+  return form.setFieldsValue({ [name]: applyMask(name, value) })
 }

--- a/src/utils/providerSpec.js
+++ b/src/utils/providerSpec.js
@@ -4,6 +4,7 @@ const ProviderSpec = {
   city: pathOr('', ['city']),
   cnpj: pathOr('', ['cnpj']),
   complement: pathOr('', ['complement']),
+  contacts: pathOr('', ['contacts']),
   email: pathOr('', ['email']),
   nameContact: pathOr('', ['nameContact']),
   neighborhood: pathOr('', ['neighborhood']),


### PR DESCRIPTION
## Contexto
Foi feito o refatoramento da página de cadastro de fornecedor em suprimentos, seguindo  o mesmo padrão das demais páginas até o momento

## Checklist
- [x] Container.
- [x] Storybook.
- [x] Page.

## Issues linkadas
- [x] Resolves #144  

## Screenshots

![image](https://user-images.githubusercontent.com/41485455/107374152-0c751280-6ac6-11eb-840d-52ab0fd2bef6.png)

## Como testar?

1. Baixar a branch `refactor/cadFornecedorSup`.
2. Testar o fluxo de cadastro de fornecedor.
