### PR TITLE
Refactor/supply output

### DIFF
--- a/src/containers/Supply/Entry/Manager/index.js
+++ b/src/containers/Supply/Entry/Manager/index.js
@@ -1,0 +1,136 @@
+import React, { useState } from 'react'
+import {
+  Button,
+  Col,
+  DatePicker,
+  Form,
+  Input,
+  Row,
+  Table,
+  Typography,
+} from 'antd'
+import { SearchOutlined } from '@ant-design/icons'
+
+import ModalRegisterSupplyEntry from '../ModalRegister'
+
+const { Title } = Typography
+
+const columns = [
+  {
+    dataIndex: 'createdAt',
+    title: 'Criado em',
+  },
+  {
+    dataIndex: 'product',
+    title: 'Produto',
+  },
+  {
+    dataIndex: 'quantity',
+    title: 'Quantidade',
+  },
+  {
+    dataIndex: 'user',
+    title: 'Usuário',
+  },
+]
+
+const expandedRowRender = (record) => {
+  const columns = [
+    { dataIndex: 'provider', title: 'Fornecedor' },
+    { dataIndex: 'price', title: 'Preço unit.' },
+    { dataIndex: 'discount', title: 'Desconto' },
+  ]
+
+  return <Table columns={columns} dataSource={[record]} pagination={false} />
+}
+
+const ManagerSupplyEntry = ({
+  dataSource,
+  formRegister,
+  handleClickNewSupplyEntry,
+  handleClickOnCancel,
+  handleOnChangeTable,
+  handleOnSearch,
+  handleSubmitRegister,
+  pagination,
+  productList,
+  providerList,
+  visibleModalRegister,
+}) => {
+  const [visibleSearch, setVisibleSearch] = useState(false)
+
+  return (
+    <>
+      <Row gutter={[0, 20]} justify="center">
+        <Col>
+          <Title level={3}>Gerenciamento de entrada (Suprimentos)</Title>
+        </Col>
+      </Row>
+
+      <Row gutter={[0, 10]} justify="end">
+        <Col>
+          <Button onClick={() => setVisibleSearch(!visibleSearch)}>
+            {visibleSearch ? 'Ocultar' : 'Filtrar'}
+          </Button>
+          <Button
+            onClick={handleClickNewSupplyEntry}
+            style={{ marginLeft: '5px' }}
+          >
+            Cadastrar nova entrada
+          </Button>
+        </Col>
+      </Row>
+
+      {visibleSearch && (
+        <Form layout="vertical" onFinish={handleOnSearch}>
+          <Row gutter={20}>
+            <Col span={8}>
+              <Form.Item label="Produto" name="product">
+                <Input allowClear placeholder="Buscar por produto" />
+              </Form.Item>
+            </Col>
+            <Col span={8}>
+              <Form.Item label="Usuário" name="username">
+                <Input allowClear placeholder="Buscar por usuário" />
+              </Form.Item>
+            </Col>
+            <Col span={6}>
+              <Form.Item label="Criado em" name="createdAt">
+                <DatePicker.RangePicker />
+              </Form.Item>
+            </Col>
+
+            <Col span={2}>
+              <Form.Item label=" ">
+                <Button
+                  htmlType="submit"
+                  icon={<SearchOutlined />}
+                  type="primary"
+                />
+              </Form.Item>
+            </Col>
+          </Row>
+        </Form>
+      )}
+
+      <ModalRegisterSupplyEntry
+        form={formRegister}
+        handleCancel={handleClickOnCancel}
+        handleSubmit={handleSubmitRegister}
+        productList={productList}
+        providerList={providerList}
+        title="Cadatro entrada (Suprimentos)"
+        visible={visibleModalRegister}
+      />
+
+      <Table
+        columns={columns}
+        dataSource={dataSource}
+        expandable={{ expandedRowRender }}
+        onChange={handleOnChangeTable}
+        pagination={pagination}
+      />
+    </>
+  )
+}
+export default ManagerSupplyEntry

--- a/src/containers/Supply/Entry/ModalRegister/index.js
+++ b/src/containers/Supply/Entry/ModalRegister/index.js
@@ -1,0 +1,72 @@
+import React from 'react'
+import { Form, InputNumber, Modal, Select } from 'antd'
+import { map } from 'ramda'
+
+const { Option } = Select
+
+const layout = {
+  labelCol: { span: 6 },
+  wrapperCol: { span: 18 },
+}
+const rules = [{ required: true }]
+
+const ModalRegisterSupplyEntry = ({
+  form,
+  handleCancel,
+  handleSubmit,
+  productList,
+  providerList,
+  title,
+  visible,
+}) => {
+  return (
+    <Modal
+      okText="Salvar"
+      onCancel={handleCancel}
+      onOk={() => form.submit()}
+      title={title}
+      visible={visible}
+    >
+      <Form {...layout} form={form} onFinish={handleSubmit}>
+        <Form.Item label="Produto" name="productId" rules={rules}>
+          <Select placeholder="Selecione o produto">
+            {map(
+              ({ id, name }) => (
+                <Option key={id} value={id}>
+                  {name}
+                </Option>
+              ),
+              productList
+            )}
+          </Select>
+        </Form.Item>
+        <Form.Item label="Fornecedor" name="providerId" rules={rules}>
+          <Select placeholder="Selecione o fornecedor">
+            {map(
+              ({ id, razaoSocial }) => (
+                <Option key={id} value={id}>
+                  {razaoSocial}
+                </Option>
+              ),
+              providerList
+            )}
+          </Select>
+        </Form.Item>
+
+        <Form.Item label="Quantidade" name="quantity" rules={rules}>
+          <InputNumber min={1} />
+        </Form.Item>
+
+        <Form.Item label="Preço" name="price" rules={rules}>
+          <InputNumber min={0} />
+        </Form.Item>
+
+        <Form.Item label="Desconto" name="discount" rules={rules}>
+          <InputNumber min={0} />
+        </Form.Item>
+      </Form>
+    </Modal>
+  )
+}
+
+export default ModalRegisterSupplyEntry

--- a/src/containers/Supply/Output/Manager/index.js
+++ b/src/containers/Supply/Output/Manager/index.js
@@ -1,0 +1,137 @@
+import React, { useState } from 'react'
+import {
+  Button,
+  Col,
+  DatePicker,
+  Form,
+  Input,
+  Row,
+  Table,
+  Typography,
+} from 'antd'
+import { SearchOutlined } from '@ant-design/icons'
+
+import ModalRegisterSupplyOutput from '../ModalRegister'
+
+const { Title } = Typography
+
+const columns = [
+  {
+    dataIndex: 'createdAt',
+    title: 'Criado em',
+  },
+  {
+    dataIndex: 'quantity',
+    title: 'Quantidade',
+  },
+  {
+    dataIndex: 'product',
+    title: 'Produto',
+  },
+  {
+    dataIndex: 'requester',
+    title: 'Solicitante',
+  },
+  {
+    dataIndex: 'user',
+    title: 'Usuário',
+  },
+]
+
+const expandedRowRender = (record) => {
+  const columns = [
+    { dataIndex: 'emailRequester', title: 'Email solicitante' },
+    { dataIndex: 'emailResponsible', title: 'Email responsável' },
+  ]
+
+  return <Table columns={columns} dataSource={[record]} pagination={false} />
+}
+
+const ManagerSupplyOutput = ({
+  dataSource,
+  formRegister,
+  handleClickNewSupplyOutput,
+  handleClickOnCancel,
+  handleOnChangeTable,
+  handleOnSearch,
+  handleSubmitRegister,
+  pagination,
+  productList,
+  visibleModalRegister,
+}) => {
+  const [visibleSearch, setVisibleSearch] = useState(false)
+
+  return (
+    <>
+      <Row gutter={[0, 20]} justify="center">
+        <Col>
+          <Title level={3}>Gerenciamento de saída (Suprimentos)</Title>
+        </Col>
+      </Row>
+
+      <Row gutter={[0, 10]} justify="end">
+        <Col>
+          <Button onClick={() => setVisibleSearch(!visibleSearch)}>
+            {visibleSearch ? 'Ocultar' : 'Filtrar'}
+          </Button>
+          <Button
+            onClick={handleClickNewSupplyOutput}
+            style={{ marginLeft: '5px' }}
+          >
+            Cadastrar nova saída
+          </Button>
+        </Col>
+      </Row>
+
+      {visibleSearch && (
+        <Form layout="vertical" onFinish={handleOnSearch}>
+          <Row gutter={20}>
+            <Col span={8}>
+              <Form.Item label="Produto" name="product">
+                <Input allowClear placeholder="Buscar por produto" />
+              </Form.Item>
+            </Col>
+            <Col span={8}>
+              <Form.Item label="Usuário" name="username">
+                <Input allowClear placeholder="Buscar por usuário" />
+              </Form.Item>
+            </Col>
+            <Col span={6}>
+              <Form.Item label="Criado em" name="createdAt">
+                <DatePicker.RangePicker />
+              </Form.Item>
+            </Col>
+
+            <Col span={2}>
+              <Form.Item label=" ">
+                <Button
+                  htmlType="submit"
+                  icon={<SearchOutlined />}
+                  type="primary"
+                />
+              </Form.Item>
+            </Col>
+          </Row>
+        </Form>
+      )}
+
+      <ModalRegisterSupplyOutput
+        form={formRegister}
+        handleCancel={handleClickOnCancel}
+        handleSubmit={handleSubmitRegister}
+        productList={productList}
+        title="Cadatro saída (Suprimentos)"
+        visible={visibleModalRegister}
+      />
+
+      <Table
+        columns={columns}
+        dataSource={dataSource}
+        expandable={{ expandedRowRender }}
+        onChange={handleOnChangeTable}
+        pagination={pagination}
+      />
+    </>
+  )
+}
+export default ManagerSupplyOutput

--- a/src/containers/Supply/Output/ModalRegister/index.js
+++ b/src/containers/Supply/Output/ModalRegister/index.js
@@ -31,8 +31,13 @@ const ModalRegisterSupplyOutput = ({
       <Form {...layout} form={form} onFinish={handleSubmit}>
         <Form.Item label="Produto" name="productId" rules={rules}>
           <Select
+            filterOption={(input, option) =>
+              option.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
+            }
             onChange={(_, { amount }) => setMax(amount)}
+            optionFilterProp="children"
             placeholder="Selecione o produto"
+            showSearch
           >
             {map(
               ({ id, name, amount }) => (

--- a/src/containers/Supply/Output/ModalRegister/index.js
+++ b/src/containers/Supply/Output/ModalRegister/index.js
@@ -1,0 +1,68 @@
+import React, { useState } from 'react'
+import { Form, Input, InputNumber, Modal, Select } from 'antd'
+import { map } from 'ramda'
+
+const { Option } = Select
+
+const layout = {
+  labelCol: { span: 6 },
+  wrapperCol: { span: 18 },
+}
+const rules = [{ required: true }]
+
+const ModalRegisterSupplyOutput = ({
+  form,
+  handleCancel,
+  handleSubmit,
+  productList,
+  title,
+  visible,
+}) => {
+  const [max, setMax] = useState(1)
+  return (
+    <Modal
+      okText="Salvar"
+      onCancel={handleCancel}
+      onOk={() => form.submit()}
+      title={title}
+      visible={visible}
+      width={650}
+    >
+      <Form {...layout} form={form} onFinish={handleSubmit}>
+        <Form.Item label="Produto" name="productId" rules={rules}>
+          <Select
+            onChange={(_, { amount }) => setMax(amount)}
+            placeholder="Selecione o produto"
+          >
+            {map(
+              ({ id, name, amount }) => (
+                <Option key={id} value={id} amount={amount}>
+                  {name}
+                </Option>
+              ),
+              productList
+            )}
+          </Select>
+        </Form.Item>
+
+        <Form.Item label="Quantidade" name="quantity" rules={rules}>
+          <InputNumber max={max} min={1} />
+        </Form.Item>
+
+        <Form.Item label="Solicitante" name="requester" rules={rules}>
+          <Input placeholder="Digite o solicitante" />
+        </Form.Item>
+
+        <Form.Item label="Email solicitante" name="emailRequester" rules={rules}>
+          <Input placeholder="Digite o email solicitante" />
+        </Form.Item>
+
+        <Form.Item label="Email responsável" name="emailResponsible">
+          <Input placeholder="Digite o email responsável" />
+        </Form.Item>
+      </Form>
+    </Modal>
+  )
+}
+
+export default ModalRegisterSupplyOutput

--- a/src/containers/Supply/Product/Manager/index.js
+++ b/src/containers/Supply/Product/Manager/index.js
@@ -18,7 +18,7 @@ const { Title } = Typography
 const columns = ({ handleClickEditSupplyProduct }) => [
   {
     dataIndex: 'code',
-    title: 'código',
+    title: 'Código',
   },
   {
     dataIndex: 'product',

--- a/src/pages/Romaneio/index.js
+++ b/src/pages/Romaneio/index.js
@@ -141,10 +141,12 @@ const Romaneio = () => {
       filters: {
         os: {
           specific: {
-            date: {
-              start: search.date,
-              end: search.date,
-            },
+            date: search.date
+              ? {
+                  start: search.date,
+                  end: search.date,
+                }
+              : undefined,
           },
         },
         product: {

--- a/src/pages/Supply/Entry/Manager/index.js
+++ b/src/pages/Supply/Entry/Manager/index.js
@@ -1,0 +1,119 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { compose, map, merge } from 'ramda'
+import { message, Form } from 'antd'
+import { connect } from 'react-redux'
+
+import ManagerSupplyEntryContainer from '../../../../containers/Supply/Entry/Manager'
+import { buildDataSouce, buildSupplyEntry } from './spec'
+import {
+  GetEntrance,
+  NovaEntrada,
+} from '../../../../services/Suprimentos/entrada'
+import { GetProvider } from '../../../../services/Suprimentos/fornecedor'
+import { GetSupProduct } from '../../../../services/Suprimentos/product'
+
+const ManagerSupplyEntry = ({ auth }) => {
+  const [current, setCurrent] = useState(1)
+  const [dataSource, setDataSource] = useState([])
+  const [formRegister] = Form.useForm()
+  const [productList, setProductList] = useState([])
+  const [providerList, setProviderList] = useState([])
+  const [queryValues, setQueryValues] = useState({})
+  const [total, setTotal] = useState(10)
+  const [visibleModalRegister, setVisibleModalRegister] = useState(false)
+
+  const getAllSupplyEntry = useCallback(() => {
+    const { createdAt, product, username } = queryValues
+
+    const query = {
+      filters: {
+        supEntrance: {
+          specific: {
+            createdAt: createdAt
+            ? {
+              end: createdAt[1]._d,
+              start: createdAt[0]._d,
+            }
+            : undefined,
+            responsibleUser: username,
+          },
+        },
+        supProduct: {
+          specific: {
+            name: product,
+          },
+        },
+      },
+      page: current,
+      total: 10,
+    }
+
+    GetEntrance(query).then(({ data: { rows, count } }) => {
+      setDataSource(map(buildDataSouce, rows))
+      setTotal(count)
+    })
+  }, [current, queryValues])
+
+
+  const handleClickOnCancel = () => {
+    formRegister.resetFields()
+    setVisibleModalRegister(false)
+  }
+
+  const handleOnSearch = (searchValue) => {
+    setQueryValues(searchValue)
+    setCurrent(1)
+  }
+
+  const handleSubmitRegister = async (formData) => {
+    try {
+      const { status } = await NovaEntrada(
+        buildSupplyEntry(merge(formData, auth))
+      )
+      if (status !== 200 && status !== 201) {
+        throw new Error('422 Unprocessable Entity!')
+      }
+      getAllSupplyEntry()
+      handleClickOnCancel()
+      message.success('Cadastro efetuado')
+    } catch (err) {
+      message.error('Erro ao efetuar cadastro')
+      console.log(err)
+    }
+  }
+
+  useEffect(() => {
+    getAllSupplyEntry()
+  }, [getAllSupplyEntry])
+
+  useEffect(() => {
+    GetSupProduct({
+      total: null,
+    }).then(({ data: { rows } }) => setProductList(rows))
+    GetProvider({
+      total: null,
+    }).then(({ data: { rows } }) => setProviderList(rows))
+  }, [])
+
+  return (
+    <ManagerSupplyEntryContainer
+      dataSource={dataSource}
+      formRegister={formRegister}
+      handleClickNewSupplyEntry={() => setVisibleModalRegister(true)}
+      handleClickOnCancel={handleClickOnCancel}
+      handleOnChangeTable={({ current }) => setCurrent(current)}
+      handleOnSearch={handleOnSearch}
+      handleSubmitRegister={handleSubmitRegister}
+      pagination={{ current, showSizeChanger: false, total }}
+      productList={productList}
+      providerList={providerList}
+      visibleModalRegister={visibleModalRegister}
+    />
+  )
+}
+
+const mapStateToProps = ({ auth }) => ({ auth })
+
+const enhanced = compose(connect(mapStateToProps))
+
+export default enhanced(ManagerSupplyEntry)

--- a/src/pages/Supply/Entry/Manager/spec.js
+++ b/src/pages/Supply/Entry/Manager/spec.js
@@ -1,0 +1,22 @@
+import moment from 'moment'
+import { applySpec, pathOr, pipe, prop, propOr } from 'ramda'
+
+export const buildSupplyEntry = applySpec({
+  amount: prop('quantity'),
+  discount: prop('discount'),
+  priceUnit: prop('price'),
+  responsibleUser: propOr('', 'username'),
+  supProductId: prop('productId'),
+  supProviderId: prop('providerId'),
+})
+
+export const buildDataSouce = applySpec({
+  createdAt: pipe(pathOr('', ['createdAt']), (date) => moment(date).format('L')),
+  discount: pathOr('', ['discount']),
+  key: pathOr('', ['id']),
+  price: pathOr('', ['priceUnit']),
+  product: pathOr('', ['supProduct' , 'name']),
+  provider: pathOr('', ['supProvider', 'razaoSocial']),
+  quantity: pathOr('', ['amount']),
+  user: pathOr('', ['responsibleUser']),
+})

--- a/src/pages/Supply/Entry/index.js
+++ b/src/pages/Supply/Entry/index.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Route, Switch } from 'react-router-dom'
+
+import SupplyEntryManager from './Manager'
+
+const SupplyEntryRoutes = () => (
+  <Switch>
+    <Route
+      component={SupplyEntryManager}
+      exact
+      path="/logged/supply/entry/manager"
+    />
+  </Switch>
+)
+
+export default SupplyEntryRoutes

--- a/src/pages/Supply/Output/Manager/index.js
+++ b/src/pages/Supply/Output/Manager/index.js
@@ -1,0 +1,107 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { compose, map, merge } from 'ramda'
+import { message, Form } from 'antd'
+import { connect } from 'react-redux'
+
+import ManagerSupplyOutputContainer from '../../../../containers/Supply/Output/Manager'
+import { buildDataSouce, buildSupplyOutput } from './spec'
+import { GetOut, NovaSaida } from '../../../../services/Suprimentos/saida'
+import { GetSupProduct } from '../../../../services/Suprimentos/product'
+
+const ManagerSupplyOutput = ({ auth }) => {
+  const [current, setCurrent] = useState(1)
+  const [dataSource, setDataSource] = useState([])
+  const [formRegister] = Form.useForm()
+  const [productList, setProductList] = useState([])
+  const [queryValues, setQueryValues] = useState({})
+  const [total, setTotal] = useState(10)
+  const [visibleModalRegister, setVisibleModalRegister] = useState(false)
+
+  const getAllSupplyOutput = useCallback(() => {
+    const { createdAt, product, username } = queryValues
+
+    const query = {
+      filters: {
+        supOut: {
+          specific: {
+            createdAt: createdAt
+            ? {
+              end: createdAt[1]._d,
+              start: createdAt[0]._d,
+            }
+            : undefined,
+            responsibleUser: username,
+          },
+        },
+        supProduct: {
+          specific: {
+            name: product,
+          },
+        },
+      },
+      page: current,
+      total: 10,
+    }
+
+    GetOut(query).then(({ data: { rows, count } }) => {
+      setDataSource(map(buildDataSouce, rows))
+      setTotal(count)
+    })
+  }, [current, queryValues])
+
+  const handleClickOnCancel = () => {
+    formRegister.resetFields()
+    setVisibleModalRegister(false)
+  }
+
+  const handleOnSearch = (searchValue) => {
+    setQueryValues(searchValue)
+    setCurrent(1)
+  }
+
+  const handleSubmitRegister = async (formData) => {
+    try {
+      const { status } = await NovaSaida(buildSupplyOutput(merge(formData, auth)))
+      if (status !== 200 && status !== 201) {
+        throw new Error('422 Unprocessable Entity!')
+      }
+      getAllSupplyOutput()
+      handleClickOnCancel()
+      message.success('Cadastro efetuado')
+    } catch (err) {
+      message.error('Erro ao efetuar cadastro')
+      console.log(err)
+    }
+  }
+
+  useEffect(() => {
+    getAllSupplyOutput()
+  }, [getAllSupplyOutput])
+
+  useEffect(() => {
+    GetSupProduct({
+      total: null,
+    }).then(({ data: { rows } }) => setProductList(rows))
+  }, [])
+
+  return (
+    <ManagerSupplyOutputContainer
+      dataSource={dataSource}
+      formRegister={formRegister}
+      handleClickNewSupplyOutput={() => setVisibleModalRegister(true)}
+      handleClickOnCancel={handleClickOnCancel}
+      handleOnChangeTable={({ current }) => setCurrent(current)}
+      handleOnSearch={handleOnSearch}
+      handleSubmitRegister={handleSubmitRegister}
+      pagination={{ current, showSizeChanger: false, total }}
+      productList={productList}
+      visibleModalRegister={visibleModalRegister}
+    />
+  )
+}
+
+const mapStateToProps = ({ auth }) => ({ auth })
+
+const enhanced = compose(connect(mapStateToProps))
+
+export default enhanced(ManagerSupplyOutput)

--- a/src/pages/Supply/Output/Manager/spec.js
+++ b/src/pages/Supply/Output/Manager/spec.js
@@ -1,0 +1,23 @@
+import moment from 'moment'
+import { applySpec, pathOr, pipe, prop, propOr } from 'ramda'
+
+export const buildSupplyOutput = applySpec({
+  amount: prop('quantity'),
+  emailResp: pathOr('', ['emailResponsible']),
+  emailSolic: prop('emailRequester'),
+  responsibleUser: propOr('', 'username'),
+  solicitante: prop('requester'),
+  supProductId: prop('productId'),
+
+})
+
+export const buildDataSouce = applySpec({
+  createdAt: pipe(pathOr('', ['createdAt']), (date) => moment(date).format('L')),
+  emailRequester: pathOr('', ['emailSolic']),
+  emailResponsible: pathOr('', ['emailResp']),
+  key: pathOr('', ['id']),
+  product: pathOr('', ['supProduct' , 'name']),
+  quantity: pathOr('', ['amount']),
+  requester: pathOr('', ['solicitante']),
+  user: pathOr('', ['responsibleUser']),
+})

--- a/src/pages/Supply/Output/index.js
+++ b/src/pages/Supply/Output/index.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Route, Switch } from 'react-router-dom'
+
+import SupplyOutputManager from './Manager'
+
+const SupplyOutputRoutes = () => (
+  <Switch>
+    <Route
+      component={SupplyOutputManager}
+      exact
+      path="/logged/supply/output/manager"
+    />
+  </Switch>
+)
+
+export default SupplyOutputRoutes

--- a/src/pages/Supply/index.js
+++ b/src/pages/Supply/index.js
@@ -3,6 +3,7 @@ import { Route, Switch } from 'react-router-dom'
 
 import SupplyEntryRoutes from './Entry'
 import SupplyManufacurerRoutes from './Manufacurer'
+import SupplyOutputRoutes from './Output'
 import SupplyProductRoutes from './Product'
 
 const SupplyRoutes = () => (
@@ -12,6 +13,7 @@ const SupplyRoutes = () => (
       component={SupplyManufacurerRoutes}
       path="/logged/supply/manufacurer"
     />
+    <Route component={SupplyOutputRoutes} path="/logged/supply/output" />
     <Route component={SupplyProductRoutes} path="/logged/supply/product" />
   </Switch>
 )

--- a/src/pages/Supply/index.js
+++ b/src/pages/Supply/index.js
@@ -1,13 +1,18 @@
 import React from 'react'
 import { Route, Switch } from 'react-router-dom'
 
+import SupplyEntryRoutes from './Entry'
 import SupplyManufacurerRoutes from './Manufacurer'
 import SupplyProductRoutes from './Product'
 
 const SupplyRoutes = () => (
   <Switch>
-    <Route path='/logged/supply/manufacurer' component={SupplyManufacurerRoutes}/>
-    <Route path='/logged/supply/product' component={SupplyProductRoutes}/>
+    <Route component={SupplyEntryRoutes} path="/logged/supply/entry" />
+    <Route
+      component={SupplyManufacurerRoutes}
+      path="/logged/supply/manufacurer"
+    />
+    <Route component={SupplyProductRoutes} path="/logged/supply/product" />
   </Switch>
 )
 

--- a/src/stories/containers/Supply/Entry/index.js
+++ b/src/stories/containers/Supply/Entry/index.js
@@ -1,0 +1,67 @@
+import React, { useState } from 'react'
+import moment from 'moment'
+import { action } from '@storybook/addon-actions'
+import { commerce, date, name, random } from 'faker'
+import { Form } from 'antd'
+
+import ManagerSupplyEntryContainer from '../../../../containers/Supply/Entry/Manager'
+
+export default {
+  title: 'Containers/Supply/Entry',
+  component: ManagerSupplyEntryContainer,
+}
+
+const dataSource = new Array(30).fill(null).map((_, key) => ({
+  createdAt: moment(date.past()).format('L'),
+  discount: random.number({ max: 10 }),
+  key,
+  price: random.number({ max: 100 }),
+  product: commerce.productName(),
+  provider: commerce.productName(),
+  quantity: random.number({ max: 100 }),
+  user: name.firstName(),
+}))
+
+const productList = new Array(30).fill(null).map((_, id) => ({
+  id,
+  name: commerce.productName(),
+}))
+
+const providerList = new Array(30).fill(null).map((_, id) => ({
+  id,
+  razaoSocial: commerce.productName(),
+}))
+
+const Template = (args) => {
+  const [formRegister] = Form.useForm()
+  const [visibleModalRegister, setVisibleModalRegister] = useState(false)
+
+  const handleClickNewSupplyEntry = () => setVisibleModalRegister(true)
+
+  const handleClickOnCancel = () => {
+    setVisibleModalRegister(false)
+    formRegister.resetFields()
+  }
+
+  return (
+    <ManagerSupplyEntryContainer
+      {...args}
+      formRegister={formRegister}
+      handleClickNewSupplyEntry={handleClickNewSupplyEntry}
+      handleClickOnCancel={handleClickOnCancel}
+      visibleModalRegister={visibleModalRegister}
+    />
+  )
+}
+
+export const Manager = Template.bind({})
+
+Manager.args = {
+  dataSource,
+  handleOnChangeTable: action('handle Change Table'),
+  handleOnSearch: action('handle On Search'),
+  handleSubmitRegister: action('handle Submit Register'),
+  pagination: { showSizeChanger: false },
+  productList,
+  providerList,
+}

--- a/src/stories/containers/Supply/Manufacturer/index.js
+++ b/src/stories/containers/Supply/Manufacturer/index.js
@@ -1,32 +1,23 @@
 import React, { useState } from 'react'
 import { action } from '@storybook/addon-actions'
-import { commerce, company, date, random } from 'faker'
+import { company, date } from 'faker'
 import { Form } from 'antd'
 import moment from 'moment'
 
-import ManagerSupplyProductContainer from '../../../../../containers/Supply/Product/Manager'
+import ManagerSupplyManufacturerContainer from '../../../../containers/Supply/Manufacturer/Manager'
 
 export default {
-  title: 'Containers/Supply/Product',
-  component: ManagerSupplyProductContainer,
+  title: 'Containers/Supply/Manufacturer',
+  component: ManagerSupplyManufacturerContainer,
 }
 
 const dataSource = new Array(30).fill(null).map((_, key) => ({
-    code: key,
-    createdAt: moment(date.past()).format('L'),
-    exporadic: random.boolean(),
-    key,
-    manufacturer: company.companyName(),
-    manufacturerId: key,
-    minimumQuantity: random.number({ max: 20 }),
-    product: commerce.productName(),
-    unit: ['UNID', 'PÇ', 'CX', 'LT'][random.number({ max: 4 })],
-  }))
-const manufacturerList = new Array(30).fill(null).map((_, key) => ({
-    id: key,
-    name: company.companyName(),
-  }))
-
+  code: key,
+  createdAt: moment(date.past()).format('L'),
+  key,
+  manufacturer: company.companyName(),
+  manufacturerId: key,
+}))
 
 const Template = (args) => {
   const [formRegister] = Form.useForm()
@@ -41,20 +32,20 @@ const Template = (args) => {
     formUpdate.resetFields()
   }
 
-  const handleClickEditSupplyProduct = (row) => {
+  const handleClickEditSupplyManufacturer = (row) => {
     formUpdate.setFieldsValue(row)
     setVisibleModalUpdate(true)
   }
 
-  const handleClickNewSupplyProduct = () => setVisibleModalRegister(true)
+  const handleClickNewSupplyManufacturer = () => setVisibleModalRegister(true)
 
   return (
-    <ManagerSupplyProductContainer
+    <ManagerSupplyManufacturerContainer
       {...args}
       formRegister={formRegister}
       formUpdate={formUpdate}
-      handleClickEditSupplyProduct={handleClickEditSupplyProduct}
-      handleClickNewSupplyProduct={handleClickNewSupplyProduct}
+      handleClickEditSupplyManufacturer={handleClickEditSupplyManufacturer}
+      handleClickNewSupplyManufacturer={handleClickNewSupplyManufacturer}
       handleClickOnCancel={handleClickOnCancel}
       visibleModalRegister={visibleModalRegister}
       visibleModalUpdate={visibleModalUpdate}
@@ -70,6 +61,5 @@ Manager.args = {
   handleOnSearch: action('handle On Search'),
   handleSubmitRegister: action('handle Submit Register'),
   handleSubmitUpdate: action('handle Submit Update'),
-  manufacturerList,
   pagination: { showSizeChanger: false },
 }

--- a/src/stories/containers/Supply/Output/index.js
+++ b/src/stories/containers/Supply/Output/index.js
@@ -1,0 +1,61 @@
+import React, { useState } from 'react'
+import moment from 'moment'
+import { action } from '@storybook/addon-actions'
+import { commerce, date, internet, name, random } from 'faker'
+import { Form } from 'antd'
+
+import ManagerSupplyOutputContainer from '../../../../containers/Supply/Output/Manager'
+
+export default {
+  title: 'Containers/Supply/Output',
+  component: ManagerSupplyOutputContainer,
+}
+
+const dataSource = new Array(30).fill(null).map((_, key) => ({
+  createdAt: moment(date.past()).format('L'),
+  emailRequester: internet.email(),
+  emailResponsible: internet.email(),
+  key,
+  product: commerce.productName(),
+  quantity: random.number({ max: 100 }),
+  requester: name.firstName(),
+  user: name.firstName(),
+}))
+
+const productList = new Array(30).fill(null).map((_, id) => ({
+  id,
+  name: commerce.productName(),
+}))
+
+const Template = (args) => {
+  const [formRegister] = Form.useForm()
+  const [visibleModalRegister, setVisibleModalRegister] = useState(false)
+
+  const handleClickNewSupplyOutput = () => setVisibleModalRegister(true)
+
+  const handleClickOnCancel = () => {
+    setVisibleModalRegister(false)
+    formRegister.resetFields()
+  }
+
+  return (
+    <ManagerSupplyOutputContainer
+      {...args}
+      formRegister={formRegister}
+      handleClickNewSupplyOutput={handleClickNewSupplyOutput}
+      handleClickOnCancel={handleClickOnCancel}
+      visibleModalRegister={visibleModalRegister}
+    />
+  )
+}
+
+export const Manager = Template.bind({})
+
+Manager.args = {
+  dataSource,
+  handleOnChangeTable: action('handle Change Table'),
+  handleOnSearch: action('handle On Search'),
+  handleSubmitRegister: action('handle Submit Register'),
+  pagination: { showSizeChanger: false },
+  productList,
+}

--- a/src/stories/containers/Supply/Product/index.js
+++ b/src/stories/containers/Supply/Product/index.js
@@ -1,23 +1,32 @@
 import React, { useState } from 'react'
 import { action } from '@storybook/addon-actions'
-import { company, date } from 'faker'
+import { commerce, company, date, random } from 'faker'
 import { Form } from 'antd'
 import moment from 'moment'
 
-import ManagerSupplyManufacturerContainer from '../../../../../containers/Supply/Manufacturer/Manager'
+import ManagerSupplyProductContainer from '../../../../containers/Supply/Product/Manager'
 
 export default {
-  title: 'Containers/Supply/Manufacturer',
-  component: ManagerSupplyManufacturerContainer,
+  title: 'Containers/Supply/Product',
+  component: ManagerSupplyProductContainer,
 }
 
 const dataSource = new Array(30).fill(null).map((_, key) => ({
-  code: key,
-  createdAt: moment(date.past()).format('L'),
-  key,
-  manufacturer: company.companyName(),
-  manufacturerId: key,
-}))
+    code: key,
+    createdAt: moment(date.past()).format('L'),
+    exporadic: random.boolean(),
+    key,
+    manufacturer: company.companyName(),
+    manufacturerId: key,
+    minimumQuantity: random.number({ max: 20 }),
+    product: commerce.productName(),
+    unit: ['UNID', 'PÇ', 'CX', 'LT'][random.number({ max: 4 })],
+  }))
+const manufacturerList = new Array(30).fill(null).map((_, key) => ({
+    id: key,
+    name: company.companyName(),
+  }))
+
 
 const Template = (args) => {
   const [formRegister] = Form.useForm()
@@ -32,20 +41,20 @@ const Template = (args) => {
     formUpdate.resetFields()
   }
 
-  const handleClickEditSupplyManufacturer = (row) => {
+  const handleClickEditSupplyProduct = (row) => {
     formUpdate.setFieldsValue(row)
     setVisibleModalUpdate(true)
   }
 
-  const handleClickNewSupplyManufacturer = () => setVisibleModalRegister(true)
+  const handleClickNewSupplyProduct = () => setVisibleModalRegister(true)
 
   return (
-    <ManagerSupplyManufacturerContainer
+    <ManagerSupplyProductContainer
       {...args}
       formRegister={formRegister}
       formUpdate={formUpdate}
-      handleClickEditSupplyManufacturer={handleClickEditSupplyManufacturer}
-      handleClickNewSupplyManufacturer={handleClickNewSupplyManufacturer}
+      handleClickEditSupplyProduct={handleClickEditSupplyProduct}
+      handleClickNewSupplyProduct={handleClickNewSupplyProduct}
       handleClickOnCancel={handleClickOnCancel}
       visibleModalRegister={visibleModalRegister}
       visibleModalUpdate={visibleModalUpdate}
@@ -61,5 +70,6 @@ Manager.args = {
   handleOnSearch: action('handle On Search'),
   handleSubmitRegister: action('handle Submit Register'),
   handleSubmitUpdate: action('handle Submit Update'),
+  manufacturerList,
   pagination: { showSizeChanger: false },
 }


### PR DESCRIPTION
## Contexto
Neste pr foi criado um página que centraliza as funções de criar e gerenciar as saídas em suprimentos

## Checklist
- [ ] Container.
- [ ] Storubook.
- [ ] Route.
- [ ] Page.

## Issues linkadas
- [ ] Resolves #145 

## Screenshots

![image](https://user-images.githubusercontent.com/50411657/107696901-4c3c2580-6c91-11eb-919a-10c19cfdb488.png)

![image](https://user-images.githubusercontent.com/50411657/107696921-52ca9d00-6c91-11eb-8824-0266f3982bb0.png)

## Como testar?


1. Baixar a branch `refactor/supplyOutput`.
2. Testar o fluxo de criar e gerenciar saídas em suprimentos na rota `/logged/supply/output/manager`.
