### PR TITLE
fix invalid date

### DIFF
--- a/src/pages/Os/Manager/specs.js
+++ b/src/pages/Os/Manager/specs.js
@@ -52,7 +52,7 @@ export const buildQueryOs = applySpec({
 
 export const buildRedirectValueOs = applySpec({
   cnpj: pathOr('', ['cnpj']),
-  date: pathOr('', ['formatedDate']),
+  date: pathOr('', ['date']),
   id: pathOr('', ['key']),
   Os: pathOr('', ['os']),
   products: pathOr([], ['products']),


### PR DESCRIPTION
## Contexto
Foi corrigido o erro em atualizar OS, no qual iniciava o valor de data de atendimento como data inváda.

## Checklist
- [ ] Corrigir erro

## Issues linkadas
- [ ] Resolves #31 

## Screenshots

![image](https://user-images.githubusercontent.com/50411657/109660683-e6ccad80-7b47-11eb-928c-25a4d718cc2b.png)

![image](https://user-images.githubusercontent.com/50411657/109660745-f946e700-7b47-11eb-9a09-277e58fbef87.png)

## Como testar?

1. Baixar a branch `fix/invalidDataUpdateOS`.
2. Testar o fluxo de aditar OS.
